### PR TITLE
fix tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -213,6 +213,7 @@ abstract class QueryTest extends PlanTest {
       case _: ObjectProducer => return
       case _: AppendColumns => return
       case _: LogicalRelation => return
+      case p if p.getClass.getSimpleName == "MetastoreRelation" => return
       case _: MemoryPlan => return
     }.transformAllExpressions {
       case a: ImperativeAggregate => return


### PR DESCRIPTION
we bypass hive tests for the json serialization stuff:
```
// bypass hive tests before we fix all corner cases in hive module.
if (this.getClass.getName.startsWith("org.apache.spark.sql.hive")) return
```

However, it doesn't work after you move the tests to catalyst package.